### PR TITLE
Fix InvalidOperationException in measurement

### DIFF
--- a/src/GraphPanel.cs
+++ b/src/GraphPanel.cs
@@ -211,7 +211,7 @@ namespace AvaloniaGraphControl
     protected override Size MeasureOverride(Size constraint)
     {
       if (Graph == null)
-        return constraint;
+        return Size.Empty;
       foreach (var child in Children)
       {
         child.Measure(constraint);


### PR DESCRIPTION
Fixes #6 

When used from ScrollViewer, the given constraint is (Infinity, Infinity), which is an invalid return value. Having no graph means the panel is empty, so (0, 0) seems appropriate.